### PR TITLE
Split cache between translation services

### DIFF
--- a/FGTranslator/FGTranslator.m
+++ b/FGTranslator/FGTranslator.m
@@ -94,7 +94,19 @@ float const FGTranslatorUnknownConfidence = -1;
 {
     NSParameterAssert(text);
     
-    return !target ? text : [text stringByAppendingFormat:@"|%@", target];
+    NSMutableString *cacheKey = [NSMutableString stringWithString:text];
+    
+    if (target) {
+        [cacheKey appendFormat:@"|%@", target];
+    }
+    
+    if (self.googleAPIKey) {
+        [cacheKey appendFormat:@"|Google"];
+    } else if (self.azureClientId && self.azureClientSecret) {
+        [cacheKey appendFormat:@"|Azure"];
+    }
+    
+    return cacheKey;
 }
 
 - (void)cacheText:(NSString *)text translated:(NSString *)translated source:(NSString *)source target: (NSString *)target


### PR DESCRIPTION
The current implementation of cache cares about the text being translated and the target language, but not the translation service, which may results in this kind of behaviour:

1. Translate "你好" using Bing, get "How are you doing"
2. Translate "你好" using Google, get "How are you doing" from cache

Expected behaviour:

1. Translate "你好" using Bing, get "How are you doing"
2. Translate "你好" using Google, get "Hello there"

Not sure if this behaviour is preferred or not, but I need this in my app so here is a PR :)